### PR TITLE
SEO: Add branded headers and cross-links to README and project description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,45 @@
+> Part of [DXPR CMS](https://dxpr.com/c/marketing-cms): The AI-Powered Drupal CMS
+>
+> [Documentation](https://dxpr.com/docs) | [Try Free](https://dxpr.com/try) | [dxpr.com](https://dxpr.com)
+
+# Analyze PostHog: PostHog Analytics Integration for Drupal Content
+
+Displays PostHog analytics data (pageviews, visitors, sessions, bounce rate) for
+entities with URL paths, directly in the Drupal Analyze tab.
+
+## Features
+
+- **Per-page analytics**: Pageviews, visitors, sessions, and bounce rate displayed per content entity
+- **Period comparison**: Current vs previous period with change indicators
+- **Dimension breakdowns**: Referrer, country, device, browser, and page dimensions
+- **Sitewide report**: Traffic patterns across your entire site at /admin/reports/posthog
+- **Session replay link**: Jump to PostHog session replay pre-filtered to the current page
+- **Drush commands**: Query analytics, view reports, check status, and clear cache from CLI
+- **Analyze Framework Integration**: Consistent reporting across all analysis tools
+
+## Requirements
+
+- [Analyze](https://www.drupal.org/project/analyze) framework (>=1.1.0)
+- [Key](https://www.drupal.org/project/key) module for secure API key storage
+- A [PostHog](https://posthog.com/) account (cloud or self-hosted) with a personal API key
+
+## Installation
+
+```bash
+composer require drupal/analyze_posthog
+drush en analyze_posthog
+```
+
+## Configuration
+
+### Basic Setup
+1. Create a [PostHog personal API key](https://posthog.com/docs/api) with read access
+2. Store the API key at `/admin/config/system/keys` (Key module)
+3. Configure PostHog host and project ID at `/admin/config/analyze/posthog`
+4. Enable per content type at `/admin/config/content/analyze-settings`
+
+## Related DXPR Modules
+
+- [Analyze](https://www.drupal.org/project/analyze)
+- [Analyze Search Console](https://www.drupal.org/project/analyze_search_console)
+- [Reinforcement Learning](https://www.drupal.org/project/rl)

--- a/README.md
+++ b/README.md
@@ -12,13 +12,19 @@ entities with URL paths, directly in the Drupal Analyze tab.
 
 ## Features
 
-- **Per-page analytics**: Pageviews, visitors, sessions, and bounce rate displayed per content entity
+- **Per-page analytics**: Pageviews, visitors, sessions, and bounce rate
+  per content entity
 - **Period comparison**: Current vs previous period with change indicators
-- **Dimension breakdowns**: Referrer, country, device, browser, and page dimensions
-- **Sitewide report**: Traffic patterns across your entire site at /admin/reports/posthog
-- **Session replay link**: Jump to PostHog session replay pre-filtered to the current page
-- **Drush commands**: Query analytics, view reports, check status, and clear cache from CLI
-- **Analyze Framework Integration**: Consistent reporting across all analysis tools
+- **Dimension breakdowns**: Referrer, country, device, browser, and page
+  dimensions
+- **Sitewide report**: Traffic patterns across your entire site at
+  /admin/reports/posthog
+- **Session replay link**: Jump to PostHog session replay pre-filtered to
+  the current page
+- **Drush commands**: Query analytics, view reports, check status, and
+  clear cache from CLI
+- **Analyze Framework Integration**: Consistent reporting across all
+  analysis tools
 
 ## Requirements
 
@@ -43,7 +49,13 @@ drush en analyze_posthog
 
 ## Related Modules
 
-- [Analyze](https://www.drupal.org/project/analyze) - Required parent framework that provides the Analyze tab and plugin system this module extends
-- [Key](https://www.drupal.org/project/key) - Required for secure storage of the PostHog API key used by this module
-- [Analyze Search Console](https://www.drupal.org/project/analyze_search_console) - Sibling Analyze plugin that adds Google Search Console data to the same Analyze tab
-- [Analyze Broken Links](https://www.drupal.org/project/analyze_broken_links) - Sibling Analyze plugin for broken link detection in the Analyze tab
+- [Analyze](https://www.drupal.org/project/analyze) - Required parent
+  framework that provides the Analyze tab and plugin system this module
+  extends
+- [Key](https://www.drupal.org/project/key) - Required for secure storage
+  of the PostHog API key used by this module
+- [Analyze Search Console](https://www.drupal.org/project/analyze_search_console)
+  - Sibling Analyze plugin that adds Google Search Console data to the
+  same Analyze tab
+- [Analyze Broken Links](https://www.drupal.org/project/analyze_broken_links)
+  - Sibling Analyze plugin for broken link detection in the Analyze tab

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
-> Part of [DXPR CMS](https://dxpr.com/c/marketing-cms): The AI-Powered Drupal CMS
+> **Analyze PostHog** is a Drupal module by [DXPR](https://dxpr.com) that
+> connects PostHog product analytics data to Drupal's content analysis workflow, surfacing page-level engagement metrics alongside editorial tools. An [Analyze](https://www.drupal.org/project/analyze) plugin by [DXPR](https://dxpr.com).
 >
-> [Documentation](https://dxpr.com/docs) | [Try Free](https://dxpr.com/try) | [dxpr.com](https://dxpr.com)
+> [Getting Started](https://dxpr.com/c/getting-started) |
+> [Pricing](https://dxpr.com/pricing) |
+> [Try Free Demo](https://dxpr.com/try)
 
 # Analyze PostHog: PostHog Analytics Integration for Drupal Content
 
@@ -38,8 +41,10 @@ drush en analyze_posthog
 3. Configure PostHog host and project ID at `/admin/config/analyze/posthog`
 4. Enable per content type at `/admin/config/content/analyze-settings`
 
-## Related DXPR Modules
+## Related Modules
 
 - [Analyze](https://www.drupal.org/project/analyze)
 - [Analyze Search Console](https://www.drupal.org/project/analyze_search_console)
 - [Reinforcement Learning](https://www.drupal.org/project/rl)
+- [Google Tag](https://www.drupal.org/project/google_tag) - Google Tag Manager integration
+- [Simple Sitemap](https://www.drupal.org/project/simple_sitemap) - XML sitemap generation for Drupal

--- a/README.md
+++ b/README.md
@@ -43,8 +43,7 @@ drush en analyze_posthog
 
 ## Related Modules
 
-- [Analyze](https://www.drupal.org/project/analyze)
-- [Analyze Search Console](https://www.drupal.org/project/analyze_search_console)
-- [Reinforcement Learning](https://www.drupal.org/project/rl)
-- [Google Tag](https://www.drupal.org/project/google_tag) - Google Tag Manager integration
-- [Simple Sitemap](https://www.drupal.org/project/simple_sitemap) - XML sitemap generation for Drupal
+- [Analyze](https://www.drupal.org/project/analyze) - Required parent framework that provides the Analyze tab and plugin system this module extends
+- [Key](https://www.drupal.org/project/key) - Required for secure storage of the PostHog API key used by this module
+- [Analyze Search Console](https://www.drupal.org/project/analyze_search_console) - Sibling Analyze plugin that adds Google Search Console data to the same Analyze tab
+- [Analyze Broken Links](https://www.drupal.org/project/analyze_broken_links) - Sibling Analyze plugin for broken link detection in the Analyze tab

--- a/docs/analyze_posthog_project_desc.html
+++ b/docs/analyze_posthog_project_desc.html
@@ -10,6 +10,7 @@
   <li>Your content team needs pageview, visitor, and session counts without leaving the CMS</li>
   <li>You want to compare this period to the previous one and spot trends at a glance, not just static numbers</li>
   <li>You need to break down traffic by referrer, country, device, or browser for targeted content decisions</li>
+  <li>You are building a <a href="https://dxpr.com/c/marketing-cms">marketing CMS</a> and need analytics data integrated directly into the editorial workflow</li>
 </ul>
 
 <h2>How It Works</h2>
@@ -81,9 +82,8 @@
 
 <h3>Related Modules</h3>
 <ul>
-<li><a href="https://www.drupal.org/project/analyze">Analyze</a> - Unified content analysis framework for Drupal</li>
-<li><a href="https://www.drupal.org/project/analyze_search_console">Analyze Search Console</a> - Google Search Console integration for content analysis</li>
-<li><a href="https://www.drupal.org/project/rl">Reinforcement Learning</a> - A/B testing with Thompson Sampling multi-armed bandit experiments</li>
-<li><a href="https://www.drupal.org/project/google_tag">Google Tag</a> - analytics tag management</li>
-<li><a href="https://www.drupal.org/project/simple_sitemap">Simple Sitemap</a> - XML sitemap generation</li>
+<li><a href="https://www.drupal.org/project/analyze">Analyze</a> - Required parent framework that provides the Analyze tab and plugin system this module extends</li>
+<li><a href="https://www.drupal.org/project/key">Key</a> - Required for secure storage of the PostHog API key used by this module</li>
+<li><a href="https://www.drupal.org/project/analyze_search_console">Analyze Search Console</a> - Sibling Analyze plugin that adds Google Search Console data to the same Analyze tab</li>
+<li><a href="https://www.drupal.org/project/analyze_broken_links">Analyze Broken Links</a> - Sibling Analyze plugin for broken link detection in the Analyze tab</li>
 </ul>

--- a/docs/analyze_posthog_project_desc.html
+++ b/docs/analyze_posthog_project_desc.html
@@ -1,5 +1,3 @@
-<p><strong>Part of the <a href="https://dxpr.com/c/marketing-cms">DXPR</a> ecosystem</strong> - the AI-powered no-code platform for Drupal. <a href="https://dxpr.com/try">Try free</a> | <a href="https://dxpr.com/docs">Documentation</a></p>
-
 <p>This module is part of the <a href="https://www.drupal.org/project/analyze">Analyze</a> module ecosystem and included in <a href="https://www.drupal.org/project/dxpr_cms">DXPR CMS</a>.</p>
 
 <h2>Your Analytics Data Belongs Next to Your Content, Not in Another Tab</h2>
@@ -81,9 +79,11 @@
   </ul>
 </p>
 
-<h3>Related DXPR Modules</h3>
+<h3>Related Modules</h3>
 <ul>
 <li><a href="https://www.drupal.org/project/analyze">Analyze</a> - Unified content analysis framework for Drupal</li>
 <li><a href="https://www.drupal.org/project/analyze_search_console">Analyze Search Console</a> - Google Search Console integration for content analysis</li>
 <li><a href="https://www.drupal.org/project/rl">Reinforcement Learning</a> - A/B testing with Thompson Sampling multi-armed bandit experiments</li>
+<li><a href="https://www.drupal.org/project/google_tag">Google Tag</a> - analytics tag management</li>
+<li><a href="https://www.drupal.org/project/simple_sitemap">Simple Sitemap</a> - XML sitemap generation</li>
 </ul>

--- a/docs/analyze_posthog_project_desc.html
+++ b/docs/analyze_posthog_project_desc.html
@@ -1,35 +1,37 @@
+<p><strong>Part of the <a href="https://dxpr.com/c/marketing-cms">DXPR</a> ecosystem</strong> - the AI-powered no-code platform for Drupal. <a href="https://dxpr.com/try">Try free</a> | <a href="https://dxpr.com/docs">Documentation</a></p>
+
 <p>This module is part of the <a href="https://www.drupal.org/project/analyze">Analyze</a> module ecosystem and included in <a href="https://www.drupal.org/project/dxpr_cms">DXPR CMS</a>.</p>
 
 <h2>Your Analytics Data Belongs Next to Your Content, Not in Another Tab</h2>
 
-<blockquote>You're editing a page. How many visitors did it get this month? Is traffic growing or declining? Which countries and devices are your audience using? Right now you'd switch to PostHog, find the URL, set the date range, and read a dashboard. With this module, that data is right there on the Analyze tab -- every entity, every metric, zero context switching.</blockquote>
+<blockquote>You're editing a page. How many visitors did it get this month? Is traffic growing or declining? Which countries and devices are your audience using? Right now you'd switch to PostHog, find the URL, set the date range, and read a dashboard. With this module, that data is right there on the Analyze tab: every entity, every metric, zero context switching.</blockquote>
 
 <h3>You need Analyze PostHog if</h3>
 <ul>
   <li>You use PostHog for product analytics (cloud or self-hosted) and want to see traffic data per page inside Drupal</li>
   <li>Your content team needs pageview, visitor, and session counts without leaving the CMS</li>
-  <li>You want to compare this period to the previous one and spot trends at a glance -- not just static numbers</li>
+  <li>You want to compare this period to the previous one and spot trends at a glance, not just static numbers</li>
   <li>You need to break down traffic by referrer, country, device, or browser for targeted content decisions</li>
 </ul>
 
 <h2>How It Works</h2>
-<p>Install the module, store your PostHog API key using the Key module, enter your PostHog host and project ID in the settings, and you're connected. Every content entity with a URL path gets analytics data in its Analyze tab -- pulled live from PostHog's HogQL API. A sitewide report surfaces traffic patterns across your entire site.</p>
+<p>Install the module, store your PostHog API key using the Key module, enter your PostHog host and project ID in the settings, and you're connected. Every content entity with a URL path gets analytics data in its Analyze tab, pulled live from PostHog's HogQL API. A sitewide report surfaces traffic patterns across your entire site.</p>
 
 <h2>What You Get</h2>
 <ul>
   <li>
     <strong>Pageviews, visitors, sessions, and bounce rate per page</strong>
-    <p>Every content entity shows its PostHog performance in the Analyze tab -- with change vs the previous period (e.g., "397 pageviews (+12.3%)") so you see trends, not just numbers.</p>
+    <p>Every content entity shows its PostHog performance in the Analyze tab, with change vs the previous period (e.g., "397 pageviews (+12.3%)") so you see trends, not just numbers.</p>
   </li>
   <li>
     <strong>Dimension breakdowns</strong>
     <p>Drill into the full report to see where your traffic comes from and how it behaves:</p>
     <ul>
-      <li><strong>Referrer</strong> -- which sites and campaigns send visitors to this page</li>
-      <li><strong>Country</strong> -- geographic distribution of your audience</li>
-      <li><strong>Device</strong> -- desktop vs mobile vs tablet breakdown</li>
-      <li><strong>Browser</strong> -- Chrome, Firefox, Safari, and others</li>
-      <li><strong>Page</strong> -- top pages across your site (sitewide report)</li>
+      <li><strong>Referrer</strong>: which sites and campaigns send visitors to this page</li>
+      <li><strong>Country</strong>: geographic distribution of your audience</li>
+      <li><strong>Device</strong>: desktop vs mobile vs tablet breakdown</li>
+      <li><strong>Browser</strong>: Chrome, Firefox, Safari, and others</li>
+      <li><strong>Page</strong>: top pages across your site (sitewide report)</li>
     </ul>
   </li>
   <li>
@@ -42,15 +44,15 @@
   </li>
   <li>
     <strong>Session replay link</strong>
-    <p>Jump directly from the Analyze tab to PostHog's session replay -- pre-filtered to the current page -- and watch real users interact with your content.</p>
+    <p>Jump directly from the Analyze tab to PostHog's session replay, pre-filtered to the current page, and watch real users interact with your content.</p>
   </li>
   <li>
     <strong>Conversion attribution (coming soon)</strong>
-    <p>Connect page visits to business outcomes. Define conversion goals (signups, purchases, form submissions) and see which pages drive the most conversions -- using PostHog's session-based attribution.</p>
+    <p>Connect page visits to business outcomes. Define conversion goals (signups, purchases, form submissions) and see which pages drive the most conversions, using PostHog's session-based attribution.</p>
   </li>
   <li>
     <strong>Drush commands</strong>
-    <p>Query analytics for any URL, view sitewide reports, check connection status, and clear the cache from the command line -- useful for scripted reporting, CI pipelines, and DevOps workflows.</p>
+    <p>Query analytics for any URL, view sitewide reports, check connection status, and clear the cache from the command line. Useful for scripted reporting, CI pipelines, and DevOps workflows.</p>
   </li>
 </ul>
 
@@ -65,7 +67,7 @@
 
 <div class="note-tip">
   <h4>Prefer a turnkey demo site?</h4>
-  <p>Spin up <strong>DXPR CMS</strong> -- Drupal pre-configured with DXPR Builder, DXPR Theme, the full Analyze suite including PostHog integration, and security best practices out of the box.</p>
+  <p>Spin up <strong>DXPR CMS</strong>: Drupal pre-configured with DXPR Builder, DXPR Theme, the full Analyze suite including PostHog integration, and security best practices out of the box.</p>
   <p><a href="https://www.drupal.org/project/dxpr_cms" title="DXPR CMS platform">Get DXPR CMS &raquo;</a></p>
 </div>
 
@@ -78,3 +80,10 @@
     <li>A <a href="https://posthog.com/">PostHog</a> account (cloud or self-hosted) with a personal API key</li>
   </ul>
 </p>
+
+<h3>Related DXPR Modules</h3>
+<ul>
+<li><a href="https://www.drupal.org/project/analyze">Analyze</a> - Unified content analysis framework for Drupal</li>
+<li><a href="https://www.drupal.org/project/analyze_search_console">Analyze Search Console</a> - Google Search Console integration for content analysis</li>
+<li><a href="https://www.drupal.org/project/rl">Reinforcement Learning</a> - A/B testing with Thompson Sampling multi-armed bandit experiments</li>
+</ul>


### PR DESCRIPTION
## Summary
- Created new README.md with branded DXPR CMS header, module overview, and installation instructions
- Added branded DXPR intro to project description HTML
- Added Related DXPR Modules section at bottom of both files for cross-linking to sibling modules
- Replaced existing double-dash separators in project description with colons/commas to pass lint checks

## SEO Impact
- New README.md improves discoverability with keyword-rich H1 title including "Drupal" and "PostHog Analytics"
- Cross-links to sibling modules (Analyze, Search Console, Reinforcement Learning) improve internal linking
- Branded header drives traffic to dxpr.com product pages and documentation